### PR TITLE
Fail gracefully if RAW_VALUE does not contain a simple integer

### DIFF
--- a/prometheus_smart_exporter/__init__.py
+++ b/prometheus_smart_exporter/__init__.py
@@ -221,6 +221,8 @@ class SMARTCollector(object):
                 metric = get_attr_metric(device, id_, name)
                 if metric is None:
                     continue
+                if attrinfo[type_] is None:
+                    continue
 
                 self.logger.debug(
                     "registering %s of #%d on metric %s",

--- a/smart_exporter_helper/__init__.py
+++ b/smart_exporter_helper/__init__.py
@@ -109,7 +109,7 @@ def read_drive_info(device):
                 "Value": int(fields[3]),
                 "Worst": int(fields[4]),
                 "Thresh": int(fields[5]),
-                "Raw": int(fields[9]),
+                "Raw": int(fields[9]) if fields[9].isdigit() else None,
             }
         )
 


### PR DESCRIPTION
The `RAW_VALUE` column in the output of smartctl can contain values that are not valid integers, leading to errors like the following:

```
"Raw": int(fields[9])
ValueError: invalid literal for int() with base 10: '0/0'
```

This commit replaces such values with `None` instead of crashing.

Fixes #2.