### PR TITLE
Don't check drives that aren't spun up

### DIFF
--- a/smart_exporter_helper/__init__.py
+++ b/smart_exporter_helper/__init__.py
@@ -69,7 +69,7 @@ ATTR_LINE = re.compile(
 def read_drive_info(device):
     try:
         data = subprocess.check_output(
-            ["smartctl", "-iA", device],
+            ["smartctl", "--nocheck=standby", "-iA", device],
         ).decode()
     except subprocess.CalledProcessError as exc:
         logger.error(


### PR DESCRIPTION
This avoids spuriously spinning up drives that are in standby mode just to get their attribute values.