### PR TITLE
Make serial number re more general

### DIFF
--- a/smart_exporter_helper/__init__.py
+++ b/smart_exporter_helper/__init__.py
@@ -43,7 +43,7 @@ DEVICE_PATH_PATTERN = re.compile(
 )
 
 SERIAL_NUMBER = re.compile(
-    r"^Serial Number:\s*(\S+)$",
+    r"^Serial [Nn]umber:\s*(\S+)$",
     re.MULTILINE,
 )
 


### PR DESCRIPTION
Some devices (eg. from Seagate) appear to use 'Serial number' instead of 'Serial Number' in the S.M.A.R.T info